### PR TITLE
Update Readme CLI Version to Latest Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or with `curl`:
 
 ```sh
 # set to the latest version - https://github.com/faros-ai/faros-events-cli/releases/latest
-$ export FAROS_CLI_VERSION="v0.0.1"
+$ export FAROS_CLI_VERSION="v0.0.2"
 $ curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/$FAROS_CLI_VERSION/faros_event.sh | bash -s help
 ```
 


### PR DESCRIPTION
## About

Now that we have v0.0.2 we should point to it in our README.