### PR TITLE
Do Not Send `compute_Application` in `build` Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ There are two ways that arguments can be passed into the script. The first, is v
 | Argument                     | Description                                                                                                                                                                                                                       | Required | Default                     | Allowed Value |
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------------------- | ------------- |
 | &#x2011;&#x2011;api_key      | Your Faros api key. See the documentation for more information on [obtaining an api key](https://docs.faros.ai/#/api?id=getting-access).                                                                                          | Yes      |                             |               |
-| &#x2011;&#x2011;app          | The name of the application that is being built. If this application does not already exist within Faros it will be created. You can view your [applications in Faros](https://app.faros.ai/default/teams/ownership/application). | Yes      |                             |               |
 | &#x2011;&#x2011;ci_source    | The CI source system that contains the build. (e.g. `Jenkins`). Please note that this field is case sensitive. If you have a feed that connects to one of these sources, this name must match exactly to be correctly associated. | Yes      |                             |               |
 | &#x2011;&#x2011;ci_org       | The unique organization within the CI source system that contains the build.                                                                                                                                                      | Yes      |                             |               |
 | &#x2011;&#x2011;pipeline     | The name of the pipeline that contains the build. If this pipeline does not already exist within Faros it will be created.                                                                                                        | Yes      |                             |               |
@@ -111,15 +110,16 @@ A `deployment` event communicates a deployment's status, destination environment
 
 ##### Deployment Arguments
 
-| Argument                                  | Description                                                                         | Required | Default        | Allowed Value                                                  |
-| ----------------------------------------- | ----------------------------------------------------------------------------------- | -------- | -------------- | -------------------------------------------------------------- |
-| &#x2011;&#x2011;deployment_env            | The environment that the application is being deployed to.                          | Yes      |                | Prod, Staging, QA, Dev, Sandbox, Custom                        |
-| &#x2011;&#x2011;deployment_status         | The status of the deployment.                                                       | Yes      |                | Success, Failed, Canceled, Queued, Running, RolledBack, Custom |
-| &#x2011;&#x2011;build                     | The unique identifier of the build that constructed the artifact being deployed.    | Yes      |                |                                                                |
-| &#x2011;&#x2011;deployment                | The unique id of the deployment.                                                    |          | Random UUID    |                                                                |
-| &#x2011;&#x2011;deployment_env_details    | Any additional details about the deployment environment that you wish to provide.   |          | ""             |                                                                |
-| &#x2011;&#x2011;deployment_status_details | Any additional details about the status of the deployment that you wish to provide. |          | ""             |                                                                |
-| &#x2011;&#x2011;source                    | The source that will be associate with the deployment.                              |          | "Faros_Script" |                                                                |
+| Argument                                  | Description                                                                                                                                                                                                                       | Required | Default        | Allowed Value                                                  |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------- | -------------------------------------------------------------- |
+| &#x2011;&#x2011;app                       | The name of the application that is being built. If this application does not already exist within Faros it will be created. You can view your [applications in Faros](https://app.faros.ai/default/teams/ownership/application). | Yes      |                |                                                                |
+| &#x2011;&#x2011;deployment_env            | The environment that the application is being deployed to.                                                                                                                                                                        | Yes      |                | Prod, Staging, QA, Dev, Sandbox, Custom                        |
+| &#x2011;&#x2011;deployment_status         | The status of the deployment.                                                                                                                                                                                                     | Yes      |                | Success, Failed, Canceled, Queued, Running, RolledBack, Custom |
+| &#x2011;&#x2011;build                     | The unique identifier of the build that constructed the artifact being deployed.                                                                                                                                                  | Yes      |                |                                                                |
+| &#x2011;&#x2011;deployment                | The unique id of the deployment.                                                                                                                                                                                                  |          | Random UUID    |                                                                |
+| &#x2011;&#x2011;deployment_env_details    | Any additional details about the deployment environment that you wish to provide.                                                                                                                                                 |          | ""             |                                                                |
+| &#x2011;&#x2011;deployment_status_details | Any additional details about the status of the deployment that you wish to provide.                                                                                                                                               |          | ""             |                                                                |
+| &#x2011;&#x2011;source                    | The source that will be associate with the deployment.                                                                                                                                                                            |          | "Faros_Script" |                                                                |
 
 ##### :mega: Sending a deployment event examples
 
@@ -160,6 +160,7 @@ The `build_deployment` should be used when there is not a distinct build that cr
 
 | Argument                                  | Description                                                                                                                                                                                                                                                                             | Required | Default           | Allowed Value                                                  |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------- | -------------------------------------------------------------- |
+| &#x2011;&#x2011;app                       | The name of the application that is being built. If this application does not already exist within Faros it will be created. You can view your [applications in Faros](https://app.faros.ai/default/teams/ownership/application).                                                       | Yes      |                   |                                                                |
 | &#x2011;&#x2011;deployment_env            | The environment that the application is being deployed to.                                                                                                                                                                                                                              | Yes      |                   | Prod, Staging, QA, Dev, Sandbox, Custom                        |
 | &#x2011;&#x2011;deployment_status         | The status of the deployment.                                                                                                                                                                                                                                                           | Yes      |                   | Success, Failed, Canceled, Queued, Running, RolledBack, Custom |
 | &#x2011;&#x2011;build_status              | The status of the build.                                                                                                                                                                                                                                                                | Yes      |                   | Success, Failed, Canceled, Queued, Running, Unknown, Custom    |
@@ -217,11 +218,11 @@ FAROS_VCS_ORG="<vcs_org>" \
 
 #### :wrench: Additional Settings Flags
 
-| Flag          | Description                            |
-| ------------- | -------------------------------------- |
-| --dry_run     | Print the event instead of sending.    |
-| --silent      | Unexceptional output will be silenced. |
-| --debug       | Helpful information will be printed.   |
+| Flag      | Description                            |
+| --------- | -------------------------------------- |
+| --dry_run | Print the event instead of sending.    |
+| --silent  | Unexceptional output will be silenced. |
+| --debug   | Helpful information will be printed.   |
 
 ## :white_check_mark: Testing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or with `curl`:
 
 ```sh
 # set to the latest version - https://github.com/faros-ai/faros-events-cli/releases/latest
-$ export FAROS_CLI_VERSION="v0.1.0"
+$ export FAROS_CLI_VERSION="v0.1.2"
 $ curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/$FAROS_CLI_VERSION/faros_event.sh | bash -s help
 ```
 

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -72,11 +72,11 @@ function help() {
     echo "---------------------------------------------------------------------------------------------------"
     printf "${RED}(Required fields)${NC}\\n"
     echo "-k / --api_key <api_key>              | FAROS_API_KEY                   |"
-    echo "--app <app>                           | FAROS_APP                       |"
     echo "--pipeline <pipeline>                 | FAROS_PIPELINE                  |"
     echo "--ci_org <ci_org>                     | FAROS_CI_ORG                    |"
     echo "--ci_source <ci_source>               | FAROS_CI_SOURCE                 |"
     printf "${RED}(Required deployment fields)${NC}\\n"
+    echo "--app <app>                           | FAROS_APP                       |"
     echo "--deployment_env <env>                | FAROS_DEPLOYMENT_ENV            | ${envs}"
     echo "--deployment_status <status>          | FAROS_DEPLOYMENT_STATUS         | ${deployment_statuses}"
     echo "--build <build>                       | FAROS_BUILD                     |"
@@ -344,7 +344,6 @@ function parsePositionalArgs() {
 function resolveInput() {
     # Required fields:
     api_key=${api_key:-$FAROS_API_KEY}
-    app=${app:-$FAROS_APP}
     pipeline=${pipeline:-$FAROS_PIPELINE}
     ci_org=${ci_org:-$FAROS_CI_ORG}
     ci_source=${ci_source:-$FAROS_CI_SOURCE}
@@ -377,6 +376,7 @@ function resolveDefaults() {
 
 function resolveDeploymentInput() {
     # Required fields:
+    app=${app:-$FAROS_APP}
     deployment_env=${deployment_env:-$FAROS_DEPLOYMENT_ENV}
     deployment_status=${deployment_status:-$FAROS_DEPLOYMENT_STATUS}
     
@@ -602,14 +602,12 @@ function makeBuildEvent() {
     makeBuild
     makeBuildCommitAssociation
     makePipeline
-    makeApplication
     makeOrganization
     request_body=$( jq -n \
         --arg origin "$origin" \
         --argjson build "$cicd_Build" \
         --argjson buildCommit "$cicd_BuildCommitAssociation" \
         --argjson pipeline "$cicd_Pipeline" \
-        --argjson application "$compute_Application" \
         --argjson organization "$cicd_Organization" \
         '{ 
             "origin": $origin,
@@ -617,7 +615,6 @@ function makeBuildEvent() {
                 $build,
                 $buildCommit,
                 $pipeline,
-                $application,
                 $organization
             ]
         }'

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -88,6 +88,7 @@ function help() {
     echo "--vcs_source <vcs_source>             | FAROS_VCS_SOURCE                |"
     echo "--commit_sha <commit_sha>             | FAROS_COMMIT_SHA                |"
     printf "${RED}(Required build_deployment fields)${NC}\\n"
+    echo "--app <app>                           | FAROS_APP                       |"
     echo "--deployment_env <env>                | FAROS_DEPLOYMENT_ENV            | ${envs}"
     echo "--deployment_status <status>          | FAROS_DEPLOYMENT_STATUS         | ${deployment_statuses}"
     echo "--build_status <status>               | FAROS_BUILD_STATUS              | ${build_statuses}"

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -65,7 +65,7 @@ Describe 'faros_event.sh'
       }
       When call build_event_test
       The output should eq ""
-      The stderr should eq "../faros_event.sh: line 421: FAROS_BUILD: unbound variable"
+      The stderr should eq "../faros_event.sh: line 422: FAROS_BUILD: unbound variable"
     End
   End
 

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -30,7 +30,6 @@ Describe 'faros_event.sh'
             FAROS_START_TIME=10 \
             FAROS_END_TIME=10 \
             ../faros_event.sh build -k "<api_key>" \
-            --app "<app_name>" \
             --build_status Success \
             --ci_org "<ci_organization>" \
             --ci_source "<ci_source>" \
@@ -43,7 +42,7 @@ Describe 'faros_event.sh'
             --no_format)
         }
         When call build_event_test
-        The output should equal 'Request Body: { "origin": "Faros_Script_Event", "entries": [ { "cicd_Build": { "uid": "<build_uid>", "startedAt": 10, "endedAt": 10, "status": { "category": "Success", "detail": "" }, "pipeline": { "uid": "<ci_pipeline>", "organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } } }, { "cicd_BuildCommitAssociation": { "build": { "uid": "<build_uid>", "pipeline": { "uid": "<ci_pipeline>", "organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } }, "commit": { "sha": "<commit_sha>", "repository": { "name": "<vcs_repo>", "organization": { "uid": "<vcs_organization>", "source": "<vcs_source>" } } } } }, { "cicd_Pipeline": { "uid": "<ci_pipeline>", "organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } }, { "compute_Application": { "name": "<app_name>", "platform": "" } }, { "cicd_Organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } ] } Dry run: Event NOT sent to Faros. Done.'
+        The output should equal 'Request Body: { "origin": "Faros_Script_Event", "entries": [ { "cicd_Build": { "uid": "<build_uid>", "startedAt": 10, "endedAt": 10, "status": { "category": "Success", "detail": "" }, "pipeline": { "uid": "<ci_pipeline>", "organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } } }, { "cicd_BuildCommitAssociation": { "build": { "uid": "<build_uid>", "pipeline": { "uid": "<ci_pipeline>", "organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } }, "commit": { "sha": "<commit_sha>", "repository": { "name": "<vcs_repo>", "organization": { "uid": "<vcs_organization>", "source": "<vcs_source>" } } } } }, { "cicd_Pipeline": { "uid": "<ci_pipeline>", "organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } }, { "cicd_Organization": { "uid": "<ci_organization>", "source": "<ci_source>" } } ] } Dry run: Event NOT sent to Faros. Done.'
     End
 
     It 'Requires --build'


### PR DESCRIPTION
We should not be sending a `compute_Application` in our build events.
