### PR TITLE
Correct Invalid Run Status Message

### DIFF
--- a/faros_event.sh
+++ b/faros_event.sh
@@ -467,7 +467,7 @@ function resolveBuildInput() {
     build_end_time=${build_end_time:-$FAROS_RUN_END_TIME}
 
     if ! [[ ${BUILD_STATUSES[*]} =~ (^|[[:space:]])"$build_status"($|[[:space:]]) ]] ; then
-      err "Invalid build status $build_status. Allowed values: ${build_statuses}";
+      err "Invalid run status $build_status. Allowed values: ${build_statuses}";
       fail
     fi
 }


### PR DESCRIPTION
Closes #

Noticed that one of our messages still referred to `build` but it should be `run` now.
