### PR TITLE
Lowercase VCS Org and Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Please make sure the following are installed before running the script:
 
 - curl
 - jq
+- sed
+- awk
 
 ### Execution
 
@@ -58,15 +60,17 @@ There are two ways that arguments can be passed into the script. The first, is v
 
 :pencil: **Note**: By convention, you can switch between using a flag or an environment variable by simply capitalizing the argument name and prefixing it with `FAROS_`. For example, `--commit` becomes `FAROS_COMMIT`, `--artifact` becomes `FAROS_ARTIFACT`.
 
-| Argument                | Description                                                                                                                              | Required | Default                     |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------------------- |
-| &#x2011;&#x2011;api_key | Your Faros API key. See the documentation for more information on [obtaining an api key](https://docs.faros.ai/#/api?id=getting-access). | Yes      |                             |
-| &#x2011;&#x2011;url     | The Faros API url to send the event to.                                                                                                      |          | `https://prod.api.faros.ai` |
-| &#x2011;&#x2011;graph   | The graph that the event should be sent to.                                                                                              |          | "default"                   |
-| &#x2011;&#x2011;origin  | The origin of the event that is being sent to Faros.                                                                                     |          | "Faros_Script_Event"        |
-| &#x2011;&#x2011;dry_run | Print the event instead of sending. (no value accepted, true if flag is present)                                                         |          | False                       |
-| &#x2011;&#x2011;silent  | Unexceptional output will be silenced. (no value accepted, true if flag is present)                                                      |          | False                       |
-| &#x2011;&#x2011;debug   | Helpful information will be printed. (no value accepted, true if flag is present)                                                        |          | False                       |
+| Argument                         | Description                                                                                                                              | Required | Default                     |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------------------- |
+| &#x2011;&#x2011;api_key          | Your Faros API key. See the documentation for more information on [obtaining an api key](https://docs.faros.ai/#/api?id=getting-access). | Yes      |                             |
+| &#x2011;&#x2011;url              | The Faros API url to send the event to.                                                                                                  |          | `https://prod.api.faros.ai` |
+| &#x2011;&#x2011;graph            | The graph that the event should be sent to.                                                                                              |          | "default"                   |
+| &#x2011;&#x2011;origin           | The origin of the event that is being sent to Faros.                                                                                     |          | "Faros_Script_Event"        |
+| &#x2011;&#x2011;dry_run          | Print the event instead of sending. (no value accepted, true if flag is present)                                                         |          | False                       |
+| &#x2011;&#x2011;silent           | Unexceptional output will be silenced. (no value accepted, true if flag is present)                                                      |          | False                       |
+| &#x2011;&#x2011;debug            | Helpful information will be printed. (no value accepted, true if flag is present)                                                        |          | False                       |
+| &#x2011;&#x2011;no_build_object  | Do not include cicd_Build in the event. (no value accepted, true if flag is present)                                                     |          | False                       |
+| &#x2011;&#x2011;no_lowercase_vcs | Do not lowercase vcs_organization and vcs_repo. (no value accepted, true if flag is present)                                             |          | False                       |
 
 #### CI Event - `CI`
 

--- a/test/demo.sh
+++ b/test/demo.sh
@@ -59,7 +59,7 @@ export FAROS_DRY_RUN=1 # Set to 0 or comment out to send the event to Faros
 # # CD Event (using commit)
 # ../faros_event.sh CD \
 #     --deploy "deploy_source://app/QA/deploy_id" \
-#     --commit "vcs_source://VCS_ORG/VCS_REPO/commit_sha" \
+#     --commit "vcs_source://vcs_org/vcs_repo/commit_sha" \
 #     --run "run_source://run_org/run_pipeline/run_id" \
 #     --deploy_status "Success" \
 #     --run_status "Success"

--- a/test/demo.sh
+++ b/test/demo.sh
@@ -17,39 +17,39 @@ export FAROS_DRY_RUN=1 # Set to 0 or comment out to send the event to Faros
 # =============================================================================
 
 # # help
-# ./faros_event.sh --help
+# ../faros_event.sh --help
 
 # # CI (minimum)
-# ./faros_event.sh CI \
+# ../faros_event.sh CI \
 #     --commit "vcs_source://vcs_org/vcs_repo/commit_sha"
 
 # # CI Event  
-# ./faros_event.sh CI \
+# ../faros_event.sh CI \
 #     --artifact "artifact_source://artifact_org/artifact_repo/artifact_id" \
 #     --commit "vcs_source://vcs_org/vcs_repo/commit_sha" \
 #     --run "run_source://run_org/run_pipeline/run_id" \
 #     --run_status "Success"
 
 # # CI Event (without artifact information)
-# ./faros_event.sh CI \
+# ../faros_event.sh CI \
 #     --commit "vcs_source://vcs_org/vcs_repo/commit_sha" \
 #     --run "run_source://run_org/run_pipeline/run_id" \
 #     --run_status "Success"
 
 # # CD Event (Minimum with --artifact)
-# ./faros_event.sh CD \
+# ../faros_event.sh CD \
 #     --deploy "deploy_source://app/QA/deploy_id" \
 #     --artifact "artifact_source://artifact_org/artifact_repo/artifact_id" \
 #     --deploy_status "Success"
 
 # # CD Event (Minimum with --commit)
-# ./faros_event.sh CD \
+# ../faros_event.sh CD \
 #     --deploy "deploy_source://app/QA/deploy_id" \
 #     --artifact "artifact_source://artifact_org/artifact_repo/artifact_id" \
 #     --deploy_status "Success"
 
 # # CD Event (with run information)
-# ./faros_event.sh CD \
+# ../faros_event.sh CD \
 #     --artifact "artifact_source://artifact_org/artifact_repo/artifact_id" \
 #     --run "run_source://run_org/run_pipeline/run_id" \
 #     --deploy "deploy_source://app/QA/deploy_id" \
@@ -57,17 +57,26 @@ export FAROS_DRY_RUN=1 # Set to 0 or comment out to send the event to Faros
 #     --run_status "Success"
 
 # # CD Event (using commit)
-# ./faros_event.sh CD \
+# ../faros_event.sh CD \
 #     --deploy "deploy_source://app/QA/deploy_id" \
-#     --commit "vcs_source://vcs_org/vcs_repo/commit_sha" \
+#     --commit "vcs_source://VCS_ORG/VCS_REPO/commit_sha" \
 #     --run "run_source://run_org/run_pipeline/run_id" \
 #     --deploy_status "Success" \
 #     --run_status "Success"
 
 # # CD Event (with --no_build_object)
-# ./faros_event.sh CD \
+# ../faros_event.sh CD \
 #     --commit "vcs_source://vcs_org/vcs_repo/commit_sha" \
 #     --run "run_source://run_org/run_pipeline/run_id" \
 #     --deploy "deploy_source://app/QA/deploy_id" \
 #     --deploy_status "Success" \
 #     --no_build_object
+
+# # CD Event (with --no_lowercase_vcs)
+# ../faros_event.sh CD \
+#     --deploy "deploy_source://app/QA/deploy_id" \
+#     --commit "vcs_source://VCS_ORG/VCS_REPO/commit_sha" \
+#     --run "run_source://run_org/run_pipeline/run_id" \
+#     --deploy_status "Success" \
+#     --run_status "Success" \
+#     --no_lowercase_vcs

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -208,7 +208,7 @@ Describe 'faros_event.sh'
   End
 
   Describe '--no_lowercase_vcs'
-    It 'constructs correct event when present'
+    It 'constructs correct commit object when present'
       ci_event_test() {
         echo $(
           ../faros_event.sh CI -k "<api_key>" \
@@ -218,10 +218,10 @@ Describe 'faros_event.sh'
         )
       }
       When call ci_event_test
-      The output should include '{ "origin": "Faros_Script_Event", "entries": [ { "cicd_Artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } } }, { "cicd_ArtifactCommitAssociation": { "artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } }, "commit": { "sha": "<commit_sha>", "repository": { "name": "<VCS_REPO>", "organization": { "uid": "<VCS_ORGANIZATION>", "source": "<vcs_source>" } } } } } ] }'
+      The output should include '"commit": { "sha": "<commit_sha>", "repository": { "name": "<VCS_REPO>", "organization": { "uid": "<VCS_ORGANIZATION>", "source": "<vcs_source>" } } }'
     End
 
-    It 'constructs correct event when absent'
+    It 'constructs correct commit object when absent'
       ci_event_test() {
         echo $(
           ../faros_event.sh CI -k "<api_key>" \
@@ -230,7 +230,7 @@ Describe 'faros_event.sh'
         )
       }
       When call ci_event_test
-      The output should include '{ "origin": "Faros_Script_Event", "entries": [ { "cicd_Artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } } }, { "cicd_ArtifactCommitAssociation": { "artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } }, "commit": { "sha": "<commit_sha>", "repository": { "name": "<vcs_repo>", "organization": { "uid": "<vcs_organization>", "source": "<vcs_source>" } } } } } ] }'
+      The output should include '"commit": { "sha": "<commit_sha>", "repository": { "name": "<vcs_repo>", "organization": { "uid": "<vcs_organization>", "source": "<vcs_source>" } } }'
     End
   End
 

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -182,7 +182,7 @@ Describe 'faros_event.sh'
         echo $(
           ../faros_event.sh CI -k "<api_key>" \
           --artifact "<artifact_source>://<artifact_org>/<artifact_repo>/<artifact>" \
-          --commit "<vcs_source>://<vcs_organization>/<vcs_repo>/<commit_sha>"
+          --commit "<vcs_source>://<VCS_ORGANIZATION>/<VCS_REPO>/<commit_sha>"
         )
       }
       When call ci_event_test
@@ -191,7 +191,7 @@ Describe 'faros_event.sh'
   End
 
   Describe '--no_build_object'
-    It 'constructs correct event CD'
+    It 'constructs correct CD event when present'
       cd_event_test() {
         echo $(
           ../faros_event.sh CD -k "<api_key>" \
@@ -204,6 +204,33 @@ Describe 'faros_event.sh'
       }
       When call cd_event_test
       The output should include '{ "origin": "Faros_Script_Event", "entries": [ { "cicd_Deployment": { "uid": "<deploy_uid>", "source": "<deploy_source>", "status": { "category": "Success", "detail": "" }, "startedAt": 10, "endedAt": 10, "env": { "category": "QA", "detail": "" }, "application": { "name": "<app_name>", "platform": "" }, "build": { "uid": "<build_uid>", "pipeline": { "uid": "<cicd_pipeline>", "organization": { "uid": "<cicd_organization>", "source": "<cicd_source>" } } } } }, { "cicd_ArtifactDeployment": { "artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } }, "deployment": { "uid": "<deploy_uid>", "source": "<deploy_source>" } } }, { "compute_Application": { "name": "<app_name>", "platform": "" } }, { "cicd_Organization": { "uid": "<cicd_organization>", "source": "<cicd_source>" } }, { "cicd_Pipeline": { "uid": "<cicd_pipeline>", "organization": { "uid": "<cicd_organization>", "source": "<cicd_source>" } } } ] }'
+    End
+  End
+
+  Describe '--no_lowercase_vcs'
+    It 'constructs correct event when present'
+      ci_event_test() {
+        echo $(
+          ../faros_event.sh CI -k "<api_key>" \
+          --artifact "<artifact_source>://<artifact_org>/<artifact_repo>/<artifact>" \
+          --commit "<vcs_source>://<VCS_ORGANIZATION>/<VCS_REPO>/<commit_sha>" \
+          --no_lowercase_vcs
+        )
+      }
+      When call ci_event_test
+      The output should include '{ "origin": "Faros_Script_Event", "entries": [ { "cicd_Artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } } }, { "cicd_ArtifactCommitAssociation": { "artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } }, "commit": { "sha": "<commit_sha>", "repository": { "name": "<VCS_REPO>", "organization": { "uid": "<VCS_ORGANIZATION>", "source": "<vcs_source>" } } } } } ] }'
+    End
+
+    It 'constructs correct event when absent'
+      ci_event_test() {
+        echo $(
+          ../faros_event.sh CI -k "<api_key>" \
+          --artifact "<artifact_source>://<artifact_org>/<artifact_repo>/<artifact>" \
+          --commit "<vcs_source>://<VCS_ORGANIZATION>/<VCS_REPO>/<commit_sha>"
+        )
+      }
+      When call ci_event_test
+      The output should include '{ "origin": "Faros_Script_Event", "entries": [ { "cicd_Artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } } }, { "cicd_ArtifactCommitAssociation": { "artifact": { "uid": "<artifact>", "repository": { "uid": "<artifact_repo>", "organization": { "uid": "<artifact_org>", "source": "<artifact_source>" } } }, "commit": { "sha": "<commit_sha>", "repository": { "name": "<vcs_repo>", "organization": { "uid": "<vcs_organization>", "source": "<vcs_source>" } } } } } ] }'
     End
   End
 

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -182,7 +182,7 @@ Describe 'faros_event.sh'
         echo $(
           ../faros_event.sh CI -k "<api_key>" \
           --artifact "<artifact_source>://<artifact_org>/<artifact_repo>/<artifact>" \
-          --commit "<vcs_source>://<VCS_ORGANIZATION>/<VCS_REPO>/<commit_sha>"
+          --commit "<vcs_source>://<vcs_organization>/<vcs_repo>/<commit_sha>"
         )
       }
       When call ci_event_test


### PR DESCRIPTION
By default, we want the CLI to lowercase the provided VCS org and repo. This PR also adds the `--no_lowercase_vcs` flag which, if present, will prevent this behavior and the CLI will use the exact provided VCS org and repo.