### PR TITLE
Providing `--artifact` and `--commit` in CD Event Should Fail

### DIFF
--- a/faros_event.sh
+++ b/faros_event.sh
@@ -415,7 +415,7 @@ function resolveCDInput() {
     fi
     if ! [ -z ${commit_uri+x} ] || ! [ -z ${FAROS_COMMIT+x} ]; then
         if ((artifact_present)); then
-            err "CD cannot have both --artifact and --commit information"
+            err "CD event cannot have both --artifact and --commit information"
             fail
         fi
         parseCommitUri

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -101,6 +101,22 @@ Describe 'faros_event.sh'
       The output should equal 'CD event requires --artifact or --commit information Failed.'
     End
 
+    It 'fails when artifact and commit both present'
+      cd_event_test() {
+        echo $(
+          ../faros_event.sh CD -k "<api_key>" \
+          --commit "<vcs_source>://<vcs_organization>/<vcs_repo>/<commit_sha>" \
+          --artifact "<artifact_source>://<artifact_org>/<artifact_repo>/<artifact>" \
+          --run "<cicd_source>://<cicd_organization>/<cicd_pipeline>/<build_uid>" \
+          --run_status Success \
+          --deploy "<deploy_source>://<app_name>/QA/<deploy_uid>" \
+          --deploy_status "Success"
+        )
+      }
+      When call cd_event_test
+      The output should equal 'CD cannot have both --artifact and --commit information Failed.'
+    End
+
     It 'requires --deploy'
       cd_event_test() {
         echo $(

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -114,7 +114,7 @@ Describe 'faros_event.sh'
         )
       }
       When call cd_event_test
-      The output should equal 'CD cannot have both --artifact and --commit information Failed.'
+      The output should equal 'CD event cannot have both --artifact and --commit information Failed.'
     End
 
     It 'requires --deploy'


### PR DESCRIPTION
## About
It is confusing that `--artifact` and `--commit` are mutually exclusive for CD events and silently only the artifact information is used. This PR causes this scenario to fail with a helpful error message.
