### PR TITLE
FAI-1122: `--no_build_object`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The script provides all the necessary instrumentation for CI/CD pipelines by sen
 
 **Requirements**: Please make sure the following are installed before running the script - `curl`, `jq`, `sed` and an implementation of `awk` (we recommend `gawk`).
 
-1. [Download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.3.0/faros_event.sh) and execute it:
+1. [Download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.3.1/faros_event.sh) and execute it:
 
 ```sh
 $ ./faros_event.sh help
@@ -19,7 +19,7 @@ $ ./faros_event.sh help
 2. Or download it with `curl` and invoke it in one command:
 
 ```sh
-$ export FAROS_CLI_VERSION="v0.3.0"
+$ export FAROS_CLI_VERSION="v0.3.1"
 $ curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/$FAROS_CLI_VERSION/faros_event.sh | bash -s help
 ```
 
@@ -30,13 +30,13 @@ $ curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/$FAROS_CLI
 1. Pull the image:
 
 ```sh
-$ docker pull farosai/faros-events-cli:v0.3.0
+$ docker pull farosai/faros-events-cli:v0.3.1
 ```
 
 2. Run it:
 
 ```sh
-$ docker run farosai/faros-events-cli:v0.3.0 help
+$ docker run farosai/faros-events-cli:v0.3.1 help
 ```
 
 ### :book: Event Types

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -125,6 +125,7 @@ function help() {
     echo "--debug             Helpful information will be printed."
     echo "--no_format         Log formatting will be turned off."
     echo "--no_lowercase_vcs  Do not lowercase VCS org and repo."
+    echo "--no_build_object   Do not include a cicd_Build in event."
     echo "--validate_only     Only validate event body against event api."
     echo
     echo "For more usage information please visit: $github_url"
@@ -238,6 +239,9 @@ function parseFlags() {
             --dry_run)
                 dry_run=1
                 shift ;;
+            --no_build_object)
+                no_build_object="true"
+                shift ;;
             --validate_only)
                 validate_only="true"
                 shift ;;
@@ -335,6 +339,7 @@ function resolveInput() {
     
     # Optional script settings: If unset then false
     no_lowercase_vcs=${no_lowercase_vcs:-0}
+    no_build_object=${no_build_object:-"false"}
     validate_only=${validate_only:-"false"}
 }
 
@@ -613,7 +618,7 @@ function sendEventToFaros() {
 
     http_response=$(curl --retry 5 --retry-delay 5 \
         --silent --write-out "HTTPSTATUS:%{http_code}" -X POST \
-        "$url/graphs/$graph/events?validateOnly=$validate_only" \
+        "$url/graphs/$graph/events?validateOnly=$validate_only&noBuild=$no_build_object" \
         -H "authorization: $api_key" \
         -H "content-type: application/json" \
         -d "$request_body") 

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-version="0.3.0"
+version="0.3.1"
 canonical_model_version="0.10.6"
 github_url="https://github.com/faros-ai/faros-events-cli"
 


### PR DESCRIPTION
## Description
I had initially hoped to remove the need for the --no_build_object functionality but I actually still think that there is a valid use-case for it. We also use it for every event sent in Heracles so this change is needed before we can upgrade the CLI version there.

## Depends on
https://github.com/faros-ai/clio/pull/309
