### PR TITLE
Deploy time updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,8 @@ jobs:
           --artifact ${{ env.EVENTS_CLI_ARTIFACT }} \
           --deploy GitHub://faros-events-cli/Prod/$GITHUB_RUN_ID \
           --deploy_status ${{ env.FAROS_RUN_STATUS }} \
+          --deploy_start_time ${{ env.CI_ENDED_AT }} \
+          --deploy_end_time ${{ env.CI_ENDED_AT }} \
           --run GitHub://faros-ai/${{ env.FAROS_PIPELINE_ID }}/$GITHUB_RUN_ID \
           --run_status ${{ env.FAROS_RUN_STATUS }} \
           --run_status_details ${{ job.status }} \
@@ -125,6 +127,8 @@ jobs:
           --artifact ${{ env.EVENTS_CLI_ARTIFACT }} \
           --deploy GitHub://faros-events-cli/Prod/$GITHUB_RUN_ID \
           --deploy_status ${{ env.FAROS_RUN_STATUS }} \
+          --deploy_start_time ${{ env.CI_ENDED_AT }} \
+          --deploy_end_time ${{ env.CI_ENDED_AT }} \
           --run GitHub://faros-ai/${{ env.FAROS_PIPELINE_ID }}/$GITHUB_RUN_ID \
           --run_status ${{ env.FAROS_RUN_STATUS }} \
           --run_status_details ${{ job.status }} \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ CLI for reporting events to Faros platform.
 
 The script provides all the necessary instrumentation for CI/CD pipelines by sending events to Faros platform
 
+## :exclamation: Notes on Updating to v0.3.x
+
+The following arguments are **no longer** defaulted to the current time. Please provide them if you wish for them to be populated.
+
+- `deploy_start_time`
+- `deploy_end_time`
+- `run_start_time`
+- `run_end_time`
+
 ## :zap: Usage
 
 ### Execute with Bash


### PR DESCRIPTION
times are no longer defaulted to now, they need to be provided.