### PR TITLE
Processing CI events for Community edition.

### DIFF
--- a/faros_event.sh
+++ b/faros_event.sh
@@ -339,7 +339,7 @@ function processEventTypes() {
 }
 
 function unix_seconds_to_iso8601() {
-    echo $(date -r "$1" -u +%FT%TZ)
+    echo $(date -r "$1" -u "+%FT%TZ")
 }
 
 function make_commit_key() {

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -339,7 +339,8 @@ function processEventTypes() {
 }
 
 function unix_seconds_to_iso8601() {
-    echo $(/bin/date -r "$1" -u "+%FT%TZ")
+    date_command=$(command -v date)
+    echo $("$date_command" -r "$1" -u "+%FT%TZ")
 }
 
 function make_commit_key() {

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -339,7 +339,7 @@ function processEventTypes() {
 }
 
 function unix_seconds_to_iso8601() {
-    echo $(date -r "$1" -u "+%FT%TZ")
+    echo $(/bin/date -r "$1" -u "+%FT%TZ")
 }
 
 function make_commit_key() {

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -39,6 +39,7 @@ dry_run=${FAROS_DRY_RUN:-0}
 silent=${FAROS_SILENT:-0}
 debug=${FAROS_DEBUG:-0}
 no_format=${FAROS_NO_FORMAT:-0}
+community_edition=${FAROS_COMMUNITY_EDITION:-0}
 
 # Theme
 RED='\033[0;31m'
@@ -148,12 +149,13 @@ main() {
         echo "No Lowercase VCS: $no_lowercase_vcs"
         echo "Skip Saving Run: $skip_saving_run"
         echo "Debug: $debug"
+        echo "Community edition: $community_edition"
     fi
 
     log "Request Body:"
     log "$request_body"
 
-    if !(($dry_run)); then
+    if !(($dry_run)) && !(($community_edition)); then
         sendEventToFaros
 
         # Log error response as an error and fail
@@ -168,7 +170,7 @@ main() {
             log "$http_response_body"
         fi
     else
-        log "Dry run: Event NOT sent to Faros."
+        log "Dry run and/or Community edition: Event NOT sent to Faros."
     fi
 
     log "Done."
@@ -261,6 +263,9 @@ function parseFlags() {
             --no_format)
                 no_format=1
                 shift ;;
+            --community_edition)
+                community_edition=1
+                shift ;;
             --help)
                 help ;;
             -v|--version)
@@ -318,6 +323,9 @@ function processEventTypes() {
         addArtifactToData
         addCommitToData
         addRunToData
+        if ((community_edition)); then
+            doCIMutations
+        fi
     elif ((cd_event)); then
         event_type="CD"
         makeEvent
@@ -326,7 +334,160 @@ function processEventTypes() {
         addArtifactToData
         addCommitToData
         addRunToData
+        # TODO: doCEMutations
     fi
+}
+
+function unix_seconds_to_iso8601() {
+    echo $(date -r "$1" -u +%FT%TZ)
+}
+
+function make_commit_key() {
+    echo $(keys_matching "$flat" "data_commit_.*")
+}
+
+function make_artifact_key() {
+    if ! [ -z "$has_artifact" ]; then
+        echo $(keys_matching "$flat" "data_artifact_.*")
+    else
+        echo $( jq -n \
+                    --arg commit_sha "$commit_sha" \
+                    --arg commit_repo "$commit_repo" \
+                    --arg commit_org "$commit_org" \
+                    --arg commit_source "$commit_source" \
+                    '{ 
+                        "data_artifact_id": $commit_sha,
+                        "data_artifact_repository": $commit_repo,
+                        "data_artifact_organization": $commit_org,
+                        "data_artifact_source": $commit_source,
+                    }'
+                )
+    fi
+}
+
+function doCIMutations() {
+    flat=$(flatten "$request_body")
+
+    artifact_key=$(make_artifact_key)
+    commit_key=$(make_commit_key)
+
+    if ! [ -z "$has_run" ]; then
+        buildKey=$(jq \
+            '{data_run_id,data_run_pipeline,data_run_organization,data_run_source}' <<< $flat
+            )
+        cicd_Artifact_with_build=$(concat "$artifact_key" "$buildKey")
+        make_mutation cicd_artifact_with_build "$cicd_Artifact_with_build"
+
+        if !(($skip_saving_run)); then
+            if [ -z "$has_run_status" ]; then
+                fail
+            fi
+            if ! [ -z "$has_run_status_details" ]; then
+                status_details=$run_status_details
+            else
+                status_details=""
+            fi
+            if ! [ -z "$has_run_start_time" ] &&
+               ! [ -z "$has_run_end_time" ]; then
+                start_time=$(unix_seconds_to_iso8601 $run_start_time)
+                end_time=$(unix_seconds_to_iso8601 $run_end_time)
+
+                cicd_Build_with_start_end=$( jq -n \
+                                --arg run_status "$run_status" \
+                                --arg run_status_details "$run_status_details" \
+                                --arg run_start_time "$start_time" \
+                                --arg run_end_time "$end_time" \
+                                '{ 
+                                    "run_status": {"category": $run_status, "detail": $run_status_details},
+                                    "run_start_time": $run_start_time,
+                                    "run_end_time": $run_end_time,
+                                }'
+                            )
+                cicd_Build_with_start_end=$(concat "$cicd_Build_with_start_end" "$buildKey")
+                make_mutation cicd_build_with_start_end "$cicd_Build_with_start_end"
+            else
+                cicd_Build=$( jq -n \
+                                --arg run_status "$run_status" \
+                                --arg run_status_details "$run_status_details" \
+                                '{
+                                    "run_status": {"category": $run_status, "detail": $run_status_details},
+                                }'
+                            )
+                cicd_Build=$(concat "$cicd_Build" "$buildKey")
+                make_mutation cicd_build "$cicd_Build"
+            fi
+
+            cicd_Pipeline=$(jq \
+            '{data_run_pipeline,data_run_organization,data_run_source}' <<< $flat
+            )
+            make_mutation cicd_pipeline "$cicd_Pipeline"
+
+            cicd_Organization_from_run=$(jq \
+            '{data_run_organization,data_run_source}' <<< $flat
+            )
+            make_mutation cicd_organization_from_run "$cicd_Organization_from_run"
+        fi
+    else
+        make_mutation cicd_artifact "$artifact_key"
+    fi
+
+    cicd_ArtifactCommitAssociation=$(concat "$artifact_key" "$commit_key")
+    make_mutation cicd_artifact_commit_association "$cicd_ArtifactCommitAssociation"
+
+    cicd_Repository=$(jq \
+            '{data_artifact_repository,data_artifact_organization,data_artifact_source}' <<< $artifact_key
+            )
+    make_mutation cicd_repository "$cicd_Repository"
+
+    cicd_Organization=$(jq \
+            '{data_artifact_organization,data_artifact_source}' <<< $artifact_key
+            )
+    make_mutation cicd_organization "$cicd_Organization"
+}
+
+function make_mutation() {
+    log Calling Hasura rest endpoint $1 with payload $2
+
+    if !(($dry_run)); then
+        log "Sending mutation to Hasura..."
+
+        hasura_url="http://localhost:8080/api/rest"
+
+        http_response=$(curl --retry 5 --retry-delay 5 \
+            --silent --write-out "HTTPSTATUS:%{http_code}" -X POST \
+            "$hasura_url/$1" \
+            -H "content-type: application/json" \
+            -d "$2") 
+
+        http_response_status=$(echo $http_response | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+        http_response_body=$(echo $http_response | sed -e 's/HTTPSTATUS\:.*//g')
+        if [ ! $http_response_status -eq 200 ]; then
+            err "[HTTP status: $http_response_status]"
+            err "Response Body:"
+            err "$http_response_body"
+            fail
+        else
+            log "[HTTP status OK: $http_response_status]"
+            log "Response Body:"
+            log "$http_response_body"
+        fi
+    fi
+}
+
+function keys_matching() {
+    echo $(jq --arg regexp "$2" \
+            'with_entries(if (.key|test($regexp)) then ( {key: .key, value: .value } ) else empty end )' <<< $1
+            )
+}
+
+function concat() {
+    echo $(jq --argjson json_2 "$2" \
+            '.+=$json_2' <<< $1
+            )
+}
+
+function flatten() {
+    echo $(jq '[paths(scalars) as $path | { ($path | map(tostring) | join("_")): getpath($path) } ] | add' <<< $1)
 }
 
 function resolveInput() {
@@ -334,8 +495,10 @@ function resolveInput() {
     if ! [ -z ${api_key+x} ] || ! [ -z ${FAROS_API_KEY+x} ]; then
         api_key=${api_key:-$FAROS_API_KEY}
     else
-        err "A Faros API key must be provided"
-        fail
+        if !(($community_edition)); then
+            err "A Faros API key must be provided"
+            fail
+        fi
     fi
 
     # Optional fields:
@@ -534,6 +697,7 @@ function addCommitToData() {
        ! [ -z "$commit_repo" ] &&
        ! [ -z "$commit_org" ] && 
        ! [ -z "$commit_source" ]; then
+        has_commit=1
         request_body=$(jq \
             --arg commit_sha "$commit_sha" \
             --arg commit_repo "$commit_repo" \
@@ -555,6 +719,7 @@ function addArtifactToData() {
        ! [ -z "$artifact_repo" ] &&
        ! [ -z "$artifact_org" ] &&
        ! [ -z "$artifact_source" ]; then
+        has_artifact=1
         request_body=$(jq \
             --arg artifact_id "$artifact_id" \
             --arg artifact_repo "$artifact_repo" \
@@ -577,6 +742,7 @@ function addRunToData() {
        ! [ -z "$run_org" ] &&
        ! [ -z "$run_pipeline" ] &&
        ! [ -z "$run_source" ]; then
+        has_run=1
         request_body=$(jq \
             --arg run_id "$run_id" \
             --arg run_pipeline "$run_pipeline" \
@@ -592,6 +758,7 @@ function addRunToData() {
         )
     fi
     if ! [ -z "$run_status" ]; then
+        has_run_status=1
         request_body=$(jq \
             --arg run_status "$run_status" \
             '.data.run +=
@@ -601,6 +768,7 @@ function addRunToData() {
         )
     fi
     if ! [ -z "$run_status_details" ]; then
+        has_run_status_details=1
         request_body=$(jq \
             --arg run_status_details "$run_status_details" \
             '.data.run +=
@@ -610,6 +778,7 @@ function addRunToData() {
         )
     fi
     if ! [ -z "$run_start_time" ]; then
+        has_run_start_time=1
         request_body=$(jq \
             --arg run_start_time "$run_start_time" \
             '.data.run +=
@@ -619,6 +788,7 @@ function addRunToData() {
         )
     fi
     if ! [ -z "$run_end_time" ]; then
+        has_run_end_time=1
         request_body=$(jq \
             --arg run_end_time "$run_end_time" \
             '.data.run +=

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -339,8 +339,7 @@ function processEventTypes() {
 }
 
 function unix_seconds_to_iso8601() {
-    date_command=$(command -v date)
-    echo $("$date_command" -r "$1" -u "+%FT%TZ")
+    echo $(jq -r 'todate' <<< $1)
 }
 
 function make_commit_key() {
@@ -392,7 +391,6 @@ function doCIMutations() {
                ! [ -z "$has_run_end_time" ]; then
                 start_time=$(unix_seconds_to_iso8601 $run_start_time)
                 end_time=$(unix_seconds_to_iso8601 $run_end_time)
-
                 cicd_Build_with_start_end=$( jq -n \
                                 --arg run_status "$run_status" \
                                 --arg run_status_details "$run_status_details" \

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -476,7 +476,7 @@ function make_mutation() {
             log "$http_response_body"
         fi
     else
-        log "Dry run: Event NOT sent to Faros."
+        log "Dry run: Mutation NOT sent to Faros."
     fi
 }
 
@@ -823,7 +823,7 @@ function fmtLog(){
     if ((no_format)); then
         fmtLog=""
     else 
-        fmtTime="[$(date +"%Y-%m-%d %T"])"
+        fmtTime="[$(jq -r -n 'now|strflocaltime("%Y-%m-%d %T")')]"
         if [ $1 == "error" ]; then
             fmtLog="$fmtTime ${RED}ERROR${NC} "
         elif [ $1 == "warn" ]; then

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -245,4 +245,96 @@ Describe 'faros_event.sh'
       The output should equal 'Resource URI could not be parsed: bad://uri The URI should be of the form: source://organization/repository/commit_sha Failed.'
     End
   End
+  Describe 'Community edition CI event'
+    cicd_organization_from_run='Calling Hasura rest endpoint cicd_organization_from_run with payload { "data_run_organization": "<run_organization>", "data_run_source": "<run_source>" }'
+    cicd_pipeline='Calling Hasura rest endpoint cicd_pipeline with payload { "data_run_pipeline": "<run_pipeline>", "data_run_organization": "<run_organization>", "data_run_source": "<run_source>" }'
+    cicd_build_with_start_end='Calling Hasura rest endpoint cicd_build_with_start_end with payload { "run_status": { "category": "Success", "detail": "Some extra details" }, "run_start_time": "1970-01-01T00:00:01Z", "run_end_time": "1970-01-01T00:00:02Z", "data_run_id": "<run_id>", "data_run_pipeline": "<run_pipeline>", "data_run_organization": "<run_organization>", "data_run_source": "<run_source>" }'
+    cicd_artifact_with_build='Calling Hasura rest endpoint cicd_artifact_with_build with payload { "data_artifact_id": "<artifact_id>", "data_artifact_repository": "<artifact_repository>", "data_artifact_organization": "<artifact_organization>", "data_artifact_source": "<artifact_source>", "data_run_id": "<run_id>", "data_run_pipeline": "<run_pipeline>", "data_run_organization": "<run_organization>", "data_run_source": "<run_source>" }'
+    cicd_organization='Calling Hasura rest endpoint cicd_organization with payload { "data_artifact_organization": "<artifact_organization>", "data_artifact_source": "<artifact_source>" }'
+    cicd_repository='Calling Hasura rest endpoint cicd_repository with payload { "data_artifact_repository": "<artifact_repository>", "data_artifact_organization": "<artifact_organization>", "data_artifact_source": "<artifact_source>" }'
+    cicd_artifact_commit_association='Calling Hasura rest endpoint cicd_artifact_commit_association with payload { "data_artifact_id": "<artifact_id>", "data_artifact_repository": "<artifact_repository>", "data_artifact_organization": "<artifact_organization>", "data_artifact_source": "<artifact_source>", "data_commit_sha": "<commit_sha>", "data_commit_repository": "<commit_repository>", "data_commit_organization": "<commit_organization>", "data_commit_source": "<commit_source>" }'
+    cicd_artifact='Calling Hasura rest endpoint cicd_artifact with payload { "data_artifact_id": "<artifact_id>", "data_artifact_repository": "<artifact_repository>", "data_artifact_organization": "<artifact_organization>", "data_artifact_source": "<artifact_source>" }'
+    cicd_build='Calling Hasura rest endpoint cicd_build with payload { "run_status": { "category": "Success", "detail": "Some extra details" }, "data_run_id": "<run_id>", "data_run_pipeline": "<run_pipeline>", "data_run_organization": "<run_organization>", "data_run_source": "<run_source>" }'
+
+    It 'All data present'
+      ci_event_test() {
+        echo $(
+          ../faros_event.sh CI \
+          --run "<run_source>://<run_organization>/<run_pipeline>/<run_id>" \
+          --commit "<commit_source>://<commit_organization>/<commit_repository>/<commit_sha>" \
+          --artifact "<artifact_source>://<artifact_organization>/<artifact_repository>/<artifact_id>" \
+          --run_status "Success" \
+          --run_status_details "Some extra details" \
+          --run_start_time "1" \
+          --run_end_time "2" \
+          --community_edition
+        )
+      }
+      When call ci_event_test
+      The output should include "$cicd_organization_from_run"
+      The output should include "$cicd_pipeline"
+      The output should include "$cicd_build_with_start_end"
+      The output should include "$cicd_artifact_with_build"
+      The output should include "$cicd_organization"
+      The output should include "$cicd_repository"
+      The output should include "$cicd_artifact_commit_association"
+    End
+    It 'No run data'
+      ci_event_test() {
+        echo $(
+          ../faros_event.sh CI \
+          --commit "<commit_source>://<commit_organization>/<commit_repository>/<commit_sha>" \
+          --artifact "<artifact_source>://<artifact_organization>/<artifact_repository>/<artifact_id>" \
+          --community_edition
+        )
+      }
+      When call ci_event_test
+      The output should include "$cicd_organization"
+      The output should include "$cicd_repository"
+      The output should include "$cicd_artifact_commit_association"
+      The output should include "$cicd_artifact"
+    End
+    It 'No run start/end time'
+      ci_event_test() {
+        echo $(
+          ../faros_event.sh CI \
+          --run "<run_source>://<run_organization>/<run_pipeline>/<run_id>" \
+          --commit "<commit_source>://<commit_organization>/<commit_repository>/<commit_sha>" \
+          --artifact "<artifact_source>://<artifact_organization>/<artifact_repository>/<artifact_id>" \
+          --run_status "Success" \
+          --run_status_details "Some extra details" \
+          --community_edition
+        )
+      }
+      When call ci_event_test
+      The output should include "$cicd_organization_from_run"
+      The output should include "$cicd_pipeline"
+      The output should include "$cicd_build"
+      The output should include "$cicd_artifact_with_build"
+      The output should include "$cicd_organization"
+      The output should include "$cicd_repository"
+      The output should include "$cicd_artifact_commit_association"
+    End
+It 'All data present and skip_saving_run'
+      ci_event_test() {
+        echo $(
+          ../faros_event.sh CI \
+          --run "<run_source>://<run_organization>/<run_pipeline>/<run_id>" \
+          --commit "<commit_source>://<commit_organization>/<commit_repository>/<commit_sha>" \
+          --artifact "<artifact_source>://<artifact_organization>/<artifact_repository>/<artifact_id>" \
+          --run_status "Success" \
+          --run_status_details "Some extra details" \
+          --run_start_time "1" \
+          --run_end_time "2" \
+          --community_edition \
+          --skip_saving_run
+        )
+      }
+      When call ci_event_test
+      The output should include "$cicd_artifact_with_build"
+      The output should include "$cicd_organization"
+      The output should include "$cicd_repository"
+      The output should include "$cicd_artifact_commit_association"
+    End
+  End
 End


### PR DESCRIPTION
Processes CI events for Community edition. Hits Hasura local instance rest API (one per mutation). Since Hasura rest is very strict about params (all params need to be consumed) there are some rest endpoints that may seem redundant (e.g., cicd_build_with_start_end and cicd_build for build entity with and without start/end time).