### PR TITLE
Passthrough start time & end time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The script provides all the necessary instrumentation for CI/CD pipelines by sen
 
 **Requirements**: Please make sure the following are installed before running the script - `curl`, `jq`, `sed` and an implementation of `awk` (we recommend `gawk`).
 
-1. [Download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.4.1/faros_event.sh) and execute it:
+1. [Download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.4.2/faros_event.sh) and execute it:
 
 ```sh
 ./faros_event.sh help
@@ -19,7 +19,7 @@ The script provides all the necessary instrumentation for CI/CD pipelines by sen
 2. Or download it with `curl` and invoke it in one command:
 
 ```sh
-export FAROS_CLI_VERSION="v0.4.1"
+export FAROS_CLI_VERSION="v0.4.2"
 curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/$FAROS_CLI_VERSION/faros_event.sh | bash -s help
 ```
 
@@ -30,13 +30,13 @@ curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/$FAROS_CLI_V
 1. Pull the image:
 
 ```sh
-docker pull farosai/faros-events-cli:v0.4.1
+docker pull farosai/faros-events-cli:v0.4.2
 ```
 
 2. Run it:
 
 ```sh
-docker run farosai/faros-events-cli:v0.4.1 help
+docker run farosai/faros-events-cli:v0.4.2 help
 ```
 
 ### :book: Event Types
@@ -106,8 +106,8 @@ A `CI` event communicates the outcome of a code build pipeline execution, and it
 | &#x2011;&#x2011;run_status         | The status of the job run that built the code.                                                                                                                | If &#x2011;&#x2011;run provided | Success, Failed, Canceled, Queued, Running, Unknown, Custom |
 | &#x2011;&#x2011;run_name           | The name of the job run that built the code.                                                                                                                  |                                 |                                                             |
 | &#x2011;&#x2011;run_status_details | Any extra details about the status of the job run.                                                                                                            |                                 |                                                             |
-| &#x2011;&#x2011;run_start_time     | The start time of the job run in milliseconds since the epoch. (e.g. `1626804346019`)                                                                         |                                 |                                                             |
-| &#x2011;&#x2011;run_end_time       | The end time of the job run in milliseconds since the epoch. (e.g. `1626804346019`)                                                                           |                                 |                                                             |
+| &#x2011;&#x2011;run_start_time     | The start time of the job run in milliseconds since the epoch, ISO-8601 string, or `Now`. (e.g. `1626804346019`, `2021-07-20T18:05:46.019Z`)                                                                         |                                 |                                                             |
+| &#x2011;&#x2011;run_end_time       | The end time of the job run in milliseconds since the epoch, ISO-8601 string, or `Now`. (e.g. `1626804346019`, `2021-07-20T18:05:46.019Z`)                                                                           |                                 |                                                             |
 
 #### CD Event - `CD`
 
@@ -126,13 +126,13 @@ A `CD` event communicates the outcome of an application deployment pipeline exec
 | &#x2011;&#x2011;deploy_app_platform   | The compute platform that runs the application.                                                                                                               |                                                           |                                                                |
 | &#x2011;&#x2011;deploy_env_details    | Any extra details about the deployment environment.                                                                                                           |                                                           |                                                                |
 | &#x2011;&#x2011;deploy_status_details | Any extra details about the status of the deployment.                                                                                                         |                                                           |                                                                |
-| &#x2011;&#x2011;deploy_start_time     | The start time of the deployment in milliseconds since the epoch. (e.g. `1626804346019`)                                                                      |                                                           |                                                                |
-| &#x2011;&#x2011;deploy_end_time       | The end time of the deployment in milliseconds since the epoch. (e.g. `1626804346019`)                                                                        |                                                           |                                                                |
+| &#x2011;&#x2011;deploy_start_time     | The start time of the deployment in milliseconds since the epoch, ISO-8601 string, or `Now`. (e.g. `1626804346019`, `2021-07-20T18:05:46.019Z`)                                                                      |                                                           |                                                                |
+| &#x2011;&#x2011;deploy_end_time       | The end time of the deployment in milliseconds since the epoch, ISO-8601 string, or `Now`. (e.g. `1626804346019`, `2021-07-20T18:05:46.019Z`)                                                                        |                                                           |                                                                |
 | &#x2011;&#x2011;run                   | The URI of the job run executing the deployment. (`<source>://<organization>/<pipeline>/<run_id>` e.g. `Jenkins://faros-ai/my-pipeline/1234`)                 |                                                           |                                                                |
 | &#x2011;&#x2011;run_status            | The status of the job run executing the deployment.                                                                                                           | If &#x2011;&#x2011;run provided                           | Success, Failed, Canceled, Queued, Running, Unknown, Custom    |
 | &#x2011;&#x2011;run_status_details    | Any extra details about the status of the job run executing the deployment.                                                                                   |                                                           |                                                                |
-| &#x2011;&#x2011;run_start_time        | The start time of the job run in milliseconds since the epoch. (e.g. `1626804346019`)                                                                         |                                                           |                                                                |
-| &#x2011;&#x2011;run_end_time          | The end time of the job run in milliseconds since the epoch. (e.g. `1626804346019`)                                                                           |                                                           |                                                                |
+| &#x2011;&#x2011;run_start_time        | The start time of the job run in milliseconds since the epoch, ISO-8601 string, or `Now`. (e.g. `1626804346019`, `2021-07-20T18:05:46.019Z`)                                                                         |                                                           |                                                                |
+| &#x2011;&#x2011;run_end_time          | The end time of the job run in milliseconds since the epoch, ISO-8601 string, or `Now`. (e.g. `1626804346019`, `2021-07-20T18:05:46.019Z`)                                                                           |                                                           |                                                                |
 
 ### Usage with Faros Community Edition
 
@@ -155,6 +155,7 @@ The following sends an event that communicates that a deployment pipeline that i
 
 ```sh
 ./faros_event.sh CD -k "<api_key>" \
+    --artifact "DockerHub://farosai/my-app-repo/285071b4d36c49fa699ae87345c3f4e61abba01b" \
     --run "Buildkite://faros-ai/payments-service-deploy-prod/4206ac01-9d2f-437d-992d-8f6857b68378" \
     --run_status "Success" \
     --run_start_time "1626804346000" \
@@ -162,8 +163,7 @@ The following sends an event that communicates that a deployment pipeline that i
     --deploy "ECS://payments-service/Prod/d-CGAKEHE8S" \
     --deploy_status "Success" \
     --deploy_start_time "1626804356000" \
-    --deploy_end_time "1626804357000" \
-    --artifact "DockerHub://farosai/my-app-repo/285071b4d36c49fa699ae87345c3f4e61abba01b"
+    --deploy_end_time "1626804357000"
 ```
 
 ---

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -777,7 +777,7 @@ function addDeployToData() {
             --arg deploy_start_time "$deploy_start_time" \
             '.data.deploy +=
             {
-                "startTime": $deploy_start_time|tonumber
+                "startTime": $deploy_start_time
             }' <<< "$request_body"
         )
     fi
@@ -786,7 +786,7 @@ function addDeployToData() {
             --arg deploy_end_time "$deploy_end_time" \
             '.data.deploy +=
             {
-                "endTime": $deploy_end_time|tonumber
+                "endTime": $deploy_end_time
             }' <<< "$request_body"
         )
     fi
@@ -891,7 +891,7 @@ function addRunToData() {
             --arg run_start_time "$run_start_time" \
             '.data.run +=
             {
-                "startTime": $run_start_time|tonumber
+                "startTime": $run_start_time
             }' <<< "$request_body"
         )
     fi
@@ -901,7 +901,7 @@ function addRunToData() {
             --arg run_end_time "$run_end_time" \
             '.data.run +=
             {
-                "endTime": $run_end_time|tonumber
+                "endTime": $run_end_time
             }' <<< "$request_body"
         )
     fi

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-version="0.4.1"
+version="0.4.2"
 canonical_model_version="0.10.10"
 github_url="https://github.com/faros-ai/faros-events-cli"
 

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -2,7 +2,7 @@ Describe 'faros_event.sh'
   export FAROS_DRY_RUN=1
   export FAROS_NO_FORMAT=1
   Describe 'CD event'
-    CDWithArtifactExpectedOutput='{"type":"CD","version":"0.0.1","origin":"Faros_Script_Event","data":{"deploy":{"id":"<deploy_uid>","environment":"QA","application":"<app_name>","source":"<deploy_source>","status":"Success","applicationPlatform":"<deploy_app_platform>","statusDetails":"<deploy_status_details>","environmentDetails":"<deploy_env_details>","startTime":3,"endTime":4},"artifact":{"id":"<artifact>","repository":"<artifact_repo>","organization":"<artifact_org>","source":"<artifact_source>"},"run":{"id":"<build_uid>","pipeline":"<cicd_pipeline>","organization":"<cicd_organization>","source":"<cicd_source>","status":"Success","statusDetails":"<run_status_details>","startTime":1,"endTime":2}}}'
+    CDWithArtifactExpectedOutput='{"type":"CD","version":"0.0.1","origin":"Faros_Script_Event","data":{"deploy":{"id":"<deploy_uid>","environment":"QA","application":"<app_name>","source":"<deploy_source>","status":"Success","applicationPlatform":"<deploy_app_platform>","statusDetails":"<deploy_status_details>","environmentDetails":"<deploy_env_details>","startTime":"3","endTime":"4"},"artifact":{"id":"<artifact>","repository":"<artifact_repo>","organization":"<artifact_org>","source":"<artifact_source>"},"run":{"id":"<build_uid>","pipeline":"<cicd_pipeline>","organization":"<cicd_organization>","source":"<cicd_source>","status":"Success","statusDetails":"<run_status_details>","startTime":"1","endTime":"2"}}}'
 
     It 'constructs correct event when artifact included using flags'
       cd_event_test() {
@@ -51,7 +51,7 @@ Describe 'faros_event.sh'
       The output should include "$CDWithArtifactExpectedOutput"
     End
 
-    CDWithCommitExpectedOutput='{"type":"CD","version":"0.0.1","origin":"Faros_Script_Event","data":{"deploy":{"id":"<deploy_uid>","environment":"QA","application":"<app_name>","source":"<deploy_source>","status":"Success","applicationPlatform":"<deploy_app_platform>","statusDetails":"<deploy_status_details>","environmentDetails":"<deploy_env_details>","startTime":3,"endTime":4},"commit":{"sha":"<commit_sha>","repository":"<vcs_repo>","organization":"<vcs_organization>","source":"<vcs_source>"},"run":{"id":"<build_uid>","pipeline":"<cicd_pipeline>","organization":"<cicd_organization>","source":"<cicd_source>","status":"Success","statusDetails":"<run_status_details>","startTime":1,"endTime":2}}}'
+    CDWithCommitExpectedOutput='{"type":"CD","version":"0.0.1","origin":"Faros_Script_Event","data":{"deploy":{"id":"<deploy_uid>","environment":"QA","application":"<app_name>","source":"<deploy_source>","status":"Success","applicationPlatform":"<deploy_app_platform>","statusDetails":"<deploy_status_details>","environmentDetails":"<deploy_env_details>","startTime":"3","endTime":"4"},"commit":{"sha":"<commit_sha>","repository":"<vcs_repo>","organization":"<vcs_organization>","source":"<vcs_source>"},"run":{"id":"<build_uid>","pipeline":"<cicd_pipeline>","organization":"<cicd_organization>","source":"<cicd_source>","status":"Success","statusDetails":"<run_status_details>","startTime":"1","endTime":"2"}}}'
 
     It 'constructs correct event when commmit included using flags'
       cd_event_test() {
@@ -147,7 +147,7 @@ Describe 'faros_event.sh'
       The output should include "$CIWithArtifactExpectedOutput"
     End
 
-    CIWithoutArtifactExpectedOutput='{"type":"CI","version":"0.0.1","origin":"Faros_Script_Event","data":{"commit":{"sha":"<commit_sha>","repository":"<vcs_repo>","organization":"<vcs_organization>","source":"<vcs_source>"},"run":{"id":"<build_uid>","pipeline":"<cicd_pipeline>","organization":"<cicd_organization>","source":"<cicd_source>","status":"Success","statusDetails":"<run_status_details>","startTime":1,"endTime":2}}}'
+    CIWithoutArtifactExpectedOutput='{"type":"CI","version":"0.0.1","origin":"Faros_Script_Event","data":{"commit":{"sha":"<commit_sha>","repository":"<vcs_repo>","organization":"<vcs_organization>","source":"<vcs_source>"},"run":{"id":"<build_uid>","pipeline":"<cicd_pipeline>","organization":"<cicd_organization>","source":"<cicd_source>","status":"Success","statusDetails":"<run_status_details>","startTime":"1","endTime":"2"}}}'
 
     It 'constructs correct event when artifact excluded using flags'
       ci_event_test() {


### PR DESCRIPTION
## About
With this [Event API change](https://github.com/faros-ai/clio/pull/349) we can now pass through the string that is provided for timestamps to the Event CLI. This now allows us to support ISO timestamps and 'Now'.