### PR TITLE
Add PR/commit association when PR number and commit data present

### DIFF
--- a/faros_event.sh
+++ b/faros_event.sh
@@ -378,7 +378,7 @@ function convert_to_iso8601() {
 }
 
 function make_commit_key() {
-    keys_matching "$flat" "data_commit_.*"
+    jq '{data_commit_sha,data_commit_repository,data_commit_organization,data_commit_source}' <<< "$flat"
 }
 
 function make_artifact_key() {
@@ -396,6 +396,21 @@ function make_artifact_key() {
               "data_artifact_organization": $commit_org,
               "data_artifact_source": $commit_source,
           }'
+    fi
+}
+
+function doPullRequestCommitMutation() {
+    if ! [ -z "$has_commit" ] &&
+       ! [ -z "$pull_request_number" ]; then
+            pull_request=$( jq -n \
+                            --arg pull_request_number "$pull_request_number" \
+                            '{
+                                "data_pull_request_uid": $pull_request_number,
+                                "data_pull_request_number": $pull_request_number|tonumber,
+                            }'
+                        )
+            pull_request_commit=$(concat "$pull_request" "$commit_key")
+            make_mutation vcs_pull_request_commit_association "$pull_request_commit"
     fi
 }
 
@@ -485,6 +500,8 @@ function doCDMutations() {
         cicd_ArtifactCommitAssociation=$(concat "$artifact_key" "$commit_key")
         make_mutation cicd_artifact_commit_association "$cicd_ArtifactCommitAssociation"
     fi
+
+    doPullRequestCommitMutation
 }
 
 function make_mutations_from_run {
@@ -563,6 +580,8 @@ function doCIMutations() {
             '{data_artifact_organization,data_artifact_source}' <<< "$artifact_key"
             )
     make_mutation cicd_organization "$cicd_Organization"
+
+    doPullRequestCommitMutation
 }
 
 function make_mutation() {
@@ -832,6 +851,7 @@ function addCommitToData() {
        ! [ -z "$commit_repo" ] &&
        ! [ -z "$commit_org" ] &&
        ! [ -z "$commit_source" ]; then
+        has_commit=1
         request_body=$(jq \
             --arg commit_sha "$commit_sha" \
             --arg commit_repo "$commit_repo" \

--- a/test/spec/faros_event_spec.sh
+++ b/test/spec/faros_event_spec.sh
@@ -402,6 +402,7 @@ Describe 'faros_event.sh'
     cicd_artifact_commit_association='Calling Hasura rest endpoint cicd_artifact_commit_association with payload { "data_artifact_id": "<artifact_id>", "data_artifact_repository": "<artifact_repository>", "data_artifact_organization": "<artifact_organization>", "data_artifact_source": "<artifact_source>", "data_commit_sha": "<commit_sha>", "data_commit_repository": "<commit_repository>", "data_commit_organization": "<commit_organization>", "data_commit_source": "<commit_source>", "data_origin": "Faros_Script_Event" }'
     cicd_artifact='Calling Hasura rest endpoint cicd_artifact with payload { "data_artifact_id": "<artifact_id>", "data_artifact_repository": "<artifact_repository>", "data_artifact_organization": "<artifact_organization>", "data_artifact_source": "<artifact_source>", "data_origin": "Faros_Script_Event" }'
     cicd_build='Calling Hasura rest endpoint cicd_build with payload { "run_status": { "category": "Success", "detail": "Some extra details" }, "data_run_id": "<run_id>", "data_run_pipeline": "<run_pipeline>", "data_run_organization": "<run_organization>", "data_run_source": "<run_source>", "data_origin": "Faros_Script_Event" }'
+    vcs_pull_request_commit_association='Calling Hasura rest endpoint vcs_pull_request_commit_association with payload { "data_pull_request_uid": "1", "data_pull_request_number": 1, "data_commit_sha": "<commit_sha>", "data_commit_repository": "<commit_repository>", "data_commit_organization": "<commit_organization>", "data_commit_source": "<commit_source>", "data_origin": "Faros_Script_Event" }'
 
     It 'All data present'
       ci_event_test() {
@@ -409,6 +410,7 @@ Describe 'faros_event.sh'
           ../faros_event.sh CI \
           --run "<run_source>://<run_organization>/<run_pipeline>/<run_id>" \
           --commit "<commit_source>://<commit_organization>/<commit_repository>/<commit_sha>" \
+          --pull_request_number 1 \
           --artifact "<artifact_source>://<artifact_organization>/<artifact_repository>/<artifact_id>" \
           --run_status "Success" \
           --run_status_details "Some extra details" \
@@ -425,6 +427,7 @@ Describe 'faros_event.sh'
       The output should include "$cicd_organization"
       The output should include "$cicd_repository"
       The output should include "$cicd_artifact_commit_association"
+      The output should include "$vcs_pull_request_commit_association"
     End
     It 'Resolves literal Now and converts to iso8601 format'
       Intercept begin
@@ -529,6 +532,7 @@ It 'All data present and skip_saving_run'
     cicd_artifact_from_commit_info='Calling Hasura rest endpoint cicd_artifact_with_build with payload { "data_artifact_id": "<commit_sha>", "data_artifact_repository": "<commit_repository>", "data_artifact_organization": "<commit_organization>", "data_artifact_source": "<commit_source>", "data_run_id": "<run_id>", "data_run_pipeline": "<run_pipeline>", "data_run_organization": "<run_organization>", "data_run_source": "<run_source>", "data_origin": "Faros_Script_Event" }'
     cicd_artifact_commit_association='Calling Hasura rest endpoint cicd_artifact_commit_association with payload { "data_artifact_id": "<commit_sha>", "data_artifact_repository": "<commit_repository>", "data_artifact_organization": "<commit_organization>", "data_artifact_source": "<commit_source>", "data_commit_sha": "<commit_sha>", "data_commit_repository": "<commit_repository>", "data_commit_organization": "<commit_organization>", "data_commit_source": "<commit_source>", "data_origin": "Faros_Script_Event" }'
     cicd_artifact_deployment_from_commit='Calling Hasura rest endpoint cicd_artifact_deployment with payload { "data_deploy_id": "<deploy_id>", "data_deploy_source": "<deploy_source>", "data_artifact_id": "<commit_sha>", "data_artifact_repository": "<commit_repository>", "data_artifact_organization": "<commit_organization>", "data_artifact_source": "<commit_source>", "data_origin": "Faros_Script_Event" }'
+    vcs_pull_request_commit_association='Calling Hasura rest endpoint vcs_pull_request_commit_association with payload { "data_pull_request_uid": "1", "data_pull_request_number": 1, "data_commit_sha": "<commit_sha>", "data_commit_repository": "<commit_repository>", "data_commit_organization": "<commit_organization>", "data_commit_source": "<commit_source>", "data_origin": "Faros_Script_Event" }'
 
     It 'All data present'
       cd_event_test() {
@@ -658,6 +662,27 @@ It 'All data present and skip_saving_run'
       The output should include "$cicd_deployment_with_build"
       The output should include "$cicd_artifact_commit_association"
       The output should include "$cicd_artifact_from_commit_info"
+    End
+    It 'Creates PR/commit association if PR number and commit data present'
+      cd_event_test() {
+        echo $(
+          ../faros_event.sh CD \
+          --commit "<commit_source>://<commit_organization>/<commit_repository>/<commit_sha>" \
+          --pull_request_number 1 \
+          --run "<run_source>://<run_organization>/<run_pipeline>/<run_id>" \
+          --run_status "Success" \
+          --run_status_details "Some extra details" \
+          --run_start_time "1000" \
+          --run_end_time "2000" \
+          --deploy "<deploy_source>://<application>/<environment>/<deploy_id>" \
+          --deploy_status "Success" \
+          --deploy_start_time "3000" \
+          --deploy_end_time "4000" \
+          --community_edition
+        )
+      }
+      When call cd_event_test
+      The output should include "$vcs_pull_request_commit_association"
     End
   End
 End


### PR DESCRIPTION
## About
Add PR/commit association when PR number and commit data present

Also, fixes the `make_commit_key` function by explicitly listing all columns that should be included in the commit key. This is needed because there was a new column (`pullRequestNumber`) added to the commit data.