### PR TITLE
Accept piped event body or `--request_body` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ CLI for reporting events to Faros platform.
 **Requirements**: `docker`
 
 ```sh
-docker pull farosai/faros-events-cli:v0.6.5 && docker run farosai/faros-events-cli:v0.6.5 help
+docker pull farosai/faros-events-cli:v0.6.6 && docker run farosai/faros-events-cli:v0.6.6 help
 ```
 
 ### Using Bash
 
 **Requirements**: `curl`, `jq`, `sed`, `awk` (we recommend `gawk`).
 
-Either [download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.5/faros_event.sh) or invoke the script directly with curl:
+Either [download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.6/faros_event.sh) or invoke the script directly with curl:
 
 ```sh
-bash <(curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.5/faros_event.sh) help
+bash <(curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.6/faros_event.sh) help
 ```
 
 ## Instrumenting CI/CD pipelines
@@ -355,19 +355,20 @@ Sometimes using the URI format required by `--run`, `--commit`, `--artifact`, or
 
 ### Additional arguments
 
-| Argument                            | Description                                                         | Default              |
-| ----------------------------------- | ------------------------------------------------------------------- | -------------------- |
-| &#x2011;&#x2011;origin              | The origin of the event that is being sent to Faros.                | "Faros_Script_Event" |
-| &#x2011;&#x2011;full                | The event being sent should be validated as a full event.           |                      |
-| &#x2011;&#x2011;silent              | Unexceptional output will be silenced.                              |                      |
-| &#x2011;&#x2011;debug               | Helpful information will be printed.                                |                      |
-| &#x2011;&#x2011;skip_saving_run     | Do not include `cicd_Build` in the event.                           |                      |
-| &#x2011;&#x2011;no_lowercase_vcs    | Do not lowercase commit_organization and commit_repo.               |                      |
-| &#x2011;&#x2011;hasura_admin_secret | The Hasura Admin Secret. Only used with `‑‑community_edition` flag. | "admin"              |
-| &#x2011;&#x2011;max_time            | The time in seconds allowed for each retry attempt.                 | 10                   |
-| &#x2011;&#x2011;retry               | The number of allowed retry attempts.                               | 3                    |
-| &#x2011;&#x2011;retry_delay         | The delay in seconds between each retry attempt.                    | 1                    |
-| &#x2011;&#x2011;retry_max_time      | The total time in seconds the request with retries can take.        | 40                   |
+| Argument                            | Description                                                             | Default              |
+| ----------------------------------- | ----------------------------------------------------------------------- | -------------------- |
+| &#x2011;&#x2011;origin              | The origin of the event that is being sent to Faros.                    | "Faros_Script_Event" |
+| &#x2011;&#x2011;request_body        | The JSON event body to be sent. Bypasses event construction in the CLI. |                      |
+| &#x2011;&#x2011;full                | The event being sent should be validated as a full event.               |                      |
+| &#x2011;&#x2011;silent              | Unexceptional output will be silenced.                                  |                      |
+| &#x2011;&#x2011;debug               | Helpful information will be printed.                                    |                      |
+| &#x2011;&#x2011;skip_saving_run     | Do not include `cicd_Build` in the event.                               |                      |
+| &#x2011;&#x2011;no_lowercase_vcs    | Do not lowercase commit_organization and commit_repo.                   |                      |
+| &#x2011;&#x2011;hasura_admin_secret | The Hasura Admin Secret. Only used with `‑‑community_edition` flag.     | "admin"              |
+| &#x2011;&#x2011;max_time            | The time in seconds allowed for each retry attempt.                     | 10                   |
+| &#x2011;&#x2011;retry               | The number of allowed retry attempts.                                   | 3                    |
+| &#x2011;&#x2011;retry_delay         | The delay in seconds between each retry attempt.                        | 1                    |
+| &#x2011;&#x2011;retry_max_time      | The total time in seconds the request with retries can take.            | 40                   |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,48 @@ As you are iterating on instrumentation you can use the `--validate-only` flag t
 ./faros_event.sh <...your command arguments...> --validate_only
 ```
 
+### Passing the request body
+
+If you would like the CLI to send an explicit request body directly to the Faros event API you can pipe the JSON event body to the script:
+
+```sh
+{
+cat <<EOF
+{
+  "type": "CD",
+  "version": "0.0.1",
+  "origin": "Faros_Script_Event",
+  "data": {
+    "deploy": {
+      "uri": "Test://test-app/Prod/1",
+      "status": "Success"
+    }
+  }
+}
+EOF
+} | ./faros_event.sh -k "<faros_api_key>"
+```
+
+or you can provide it to the `--request_body` flag:
+
+```sh
+./faros_event.sh -k "<faros_api_key>" \
+--request_body "$(cat <<EOF
+{
+  "type": "CD",
+  "version": "0.0.1",
+  "origin": "Faros_Script_Event",
+  "data": {
+    "deploy": {
+      "uri": "Test://test-app/Prod/1",
+      "status": "Success"
+    }
+  }
+}
+EOF
+)"
+```
+
 ### Usage with Faros Community Edition
 
 > :exclamation: Sending events in parts is not currently supported

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -184,6 +184,7 @@ function help() {
     echo "--silent            Unexceptional output will be silenced."
     echo "--debug             Helpful information will be printed."
     echo "--no_format         Log formatting will be turned off."
+    echo "--request_body      The explicit request body to send to the event API."
     echo "--full              Event should be validated as a full event."
     echo "--skip-saving-run   Do not include a cicd_Build in event."
     echo "--validate_only     Only validate event body against event api."

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -1087,7 +1087,7 @@ main() {
     processArgs "$@"            # Determine which event types are present
     resolveInput                # Resolve general fields
 
-    # Event body explicitly provided. Bypass event construction
+    # Event body not explicitly provided. Construct event
     if [ -z "$request_body" ]; then
         processEventTypes       # Resolve input and populate event
     fi

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -23,7 +23,7 @@ fi
 
 # Allows the event body to be piped to the scripts
 if [ -p /dev/stdin ]; then
-    request_body=$(cat "/dev/stdin")
+    request_body=$(cat)
 fi
 
 # Defaults
@@ -363,6 +363,9 @@ function processEventTypes() {
         resolveTestExecutionInput
         addTestToData
         addCommitToData
+    else
+        err "Event type must be provided"
+        fail
     fi
 }
 
@@ -660,6 +663,7 @@ function resolveInput() {
     resolveDefaults
     graph=${graph:-$FAROS_GRAPH}
     origin=${origin:-$FAROS_ORIGIN}
+    request_body=${request_body:-$FAROS_REQUEST_BODY}
     if ! ((community_edition)); then
         url=${url:-$FAROS_URL}
     else


### PR DESCRIPTION
This allows sending JSON directly to the event API via the CLI and the CLI provides some handholding around the URL, graph, authorization and query params. I thought this would be useful but maybe we should just have people use cURL and the Event API directly instead of this.