### PR TITLE
Handling of no event type being passed in the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       with:
         ignore: test
       env:
-        SHELLCHECK_OPTS: -s bash -e SC2059 -e SC2237 -e SC2004 -e SC2001
+        SHELLCHECK_OPTS: -s bash -e SC2059 -e SC2237 -e SC2004 -e SC2001 -e SC2317

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -296,7 +296,7 @@ function parseFlags() {
 # Determine which event types are present
 function processArgs() {
     # No positional arg passed - show help
-    if ! (($#)) || [ "$1" == "help" ]; then
+    if ! (($#)) || [ "$1" == "help" ] || [ -z "$1" ]; then
         help
         exit 0
     fi

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -189,7 +189,6 @@ function help() {
     echo "--retry-max-time    The total time in seconds the request with retries can take"
     echo
     echo "For more usage information please visit: $github_url"
-    exit 0
 }
 
 function parseFlags() {
@@ -284,7 +283,7 @@ function parseFlags() {
             --debug)                    debug=1                     && shift ;;
             --no_format)                no_format=1                 && shift ;;
             --community_edition)        community_edition=1         && shift ;;
-            --help)                     help ;;
+            --help)                     help exit 0 ;;
             -v|--version)               echo "$version" exit 0 ;;
             *)
                 POSITIONAL+=("$1") # save it in an array for later


### PR DESCRIPTION
## About
Handles correctly no event type being passed.

For some reason, if you send

```
./faros_event.sh --dry_run --commit "GitHub://foobar"
```
and check `$#` at the beginning of processArgs, you get `1` but `$1` is empty, which results in the script NOT early exiting with the help.
