### PR TITLE
Use export instead of declare -g

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ CLI for reporting events to Faros platform.
 **Requirements**: `docker`
 
 ```sh
-docker pull farosai/faros-events-cli:v0.6.7 && docker run farosai/faros-events-cli:v0.6.7 help
+docker pull farosai/faros-events-cli:v0.6.8 && docker run farosai/faros-events-cli:v0.6.8 help
 ```
 
 ### Using Bash
 
 **Requirements**: `curl`, `jq` (1.6+), `sed`, `awk` (we recommend `gawk`).
 
-Either [download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.7/faros_event.sh) or invoke the script directly with curl:
+Either [download the script manually](https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.8/faros_event.sh) or invoke the script directly with curl:
 
 ```sh
-bash <(curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.7/faros_event.sh) help
+bash <(curl -s https://raw.githubusercontent.com/faros-ai/faros-events-cli/v0.6.8/faros_event.sh) help
 ```
 
 ## Instrumenting CI/CD pipelines

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -304,8 +304,7 @@ function parseFlags() {
 }
 
 function setFlag() {
-    var_name="$2"
-    declare -g "$var_name"="$3"
+    export "$2"="$3"
     debug "| $1 [ $3 ]"
 }
 

--- a/faros_event.sh
+++ b/faros_event.sh
@@ -6,7 +6,7 @@ test || __() { :; }
 
 set -eo pipefail
 
-version="0.6.7"
+version="0.6.8"
 canonical_model_version="0.12.14"
 github_url="https://github.com/faros-ai/faros-events-cli"
 


### PR DESCRIPTION
Closes #105

## About
`declare -g` is not supported by some instances of MacOS. We should use the more general `export` command to achieve the functionality we need.